### PR TITLE
Support for latest torchvision - get_image_size

### DIFF
--- a/transforms.py
+++ b/transforms.py
@@ -120,7 +120,7 @@ class RandomResizedCropWithLocation(torch.nn.Module):
             tuple: params (i, j, h, w) to be passed to ``crop`` for a random
                 sized crop.
         """
-        width, height = FT._get_image_size(img)
+        width, height = FT.get_image_size(img)
         area = height * width
 
         log_ratio = torch.log(torch.tensor(ratio))


### PR DESCRIPTION
Private function _get_image_size was changed to public in torchvision v0.11.

The use of torchvision v0.11 and above will result in the following error: https://github.com/pytorch/vision/issues/4328