### PR TITLE
Fix evaluate() calls where stats_file was not initialized

### DIFF
--- a/main_vicregl.py
+++ b/main_vicregl.py
@@ -102,7 +102,10 @@ def main(args):
     init_distributed_mode(args)
     print(args)
     gpu = torch.device(args.device)
-
+    
+    # Ensures that stats_file is initialized when calling evalaute(),
+    # even if only the rank 0 process will use it
+    stats_file = None
     if args.rank == 0:
         args.exp_dir.mkdir(parents=True, exist_ok=True)
         stats_file = open(args.exp_dir / "stats.txt", "a", buffering=1)


### PR DESCRIPTION
Currently when using the options "--evaluate" or "--evaluate-only", the calls to `evaluate()` throw and error (see anonymized stack trace below) since `stats_file` is only instantiated for the process of rank 0.

```
submitit ERROR (2023-02-21 12:13:12,969) - Submitted job triggered an exception
ERROR:submitit:Submitted job triggered an exception
Traceback (most recent call last):
  File "ENV_PATH/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "ENV_PATH/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "ENV_PATH/lib/python3.9/site-packages/submitit/core/_submit.py", line 11, in <module>
    submitit_main()
  File "ENV_PATH/lib/python3.9/site-packages/submitit/core/submission.py", line 71, in submitit_main
    process_job(args.folder)
  File "ENV_PATH/lib/python3.9/site-packages/submitit/core/submission.py", line 64, in process_job
    raise error
  File "ENV_PATH/lib/python3.9/site-packages/submitit/core/submission.py", line 53, in process_job
    result = delayed.result()
  File "ENV_PATH/lib/python3.9/site-packages/submitit/core/utils.py", line 128, in result
    self._result = self.function(*self.args, **self.kwargs)
  File "CODE_ROOT/VICRegL/run_with_submitit.py", line 71, in __call__
    main_vicregl.main(self.args)
  File "CODE_ROOT/VICRegL/main_vicregl.py", line 198, in main
    evaluate(model, logs, val_loader, args, epoch, lr, stats_file, gpu)
UnboundLocalError: local variable 'stats_file' referenced before assignment
```

A simple fix (though not necessarily the cleanest) is just to instantiate it as None for all other processes so that the function call does not fail.